### PR TITLE
refactor IMSIC for more flexible integration when multi-clock design happens.

### DIFF
--- a/src/main/scala/Example-axi.scala
+++ b/src/main/scala/Example-axi.scala
@@ -49,7 +49,7 @@ class AXI4AIA()(implicit p: Parameters) extends LazyModule {
     })(Parameters.empty)).node
 
     val imsic = LazyModule(new AXI4IMSIC(imsic_params)(Parameters.empty))
-    imsic.fromMem := map := imsics_fromMem_xbar
+    imsic.axireg.fromMem := map := imsics_fromMem_xbar
     imsic
   })
 

--- a/src/main/scala/IMSIC.scala
+++ b/src/main/scala/IMSIC.scala
@@ -325,7 +325,8 @@ class TLIMSIC(
     private val reggen = Module(new RegGen(params, beatBytes))
     toCSR := imsic.toCSR
     imsic.fromCSR := fromCSR
-
+    imsic.io.seteipnum := reggen.io.seteipnum
+    imsic.io.valid := reggen.io.valid
     (intfileFromMems zip reggen.regmapIOs).map {
       case (intfileFromMem, regmapIO) => intfileFromMem.regmap(regmapIO._1, regmapIO._2)
     }

--- a/src/main/scala/IMSIC.scala
+++ b/src/main/scala/IMSIC.scala
@@ -266,7 +266,7 @@ class IMSIC(
         }
         val intFile = Module(new IntFile)
         intFile.fromCSR.seteipnum.bits  := io.seteipnum
-        intFile.fromCSR.seteipnum.valid := io.valid(j)
+        intFile.fromCSR.seteipnum.valid := io.valid(flati)
         intFile.fromCSR.addr            := sel(fromCSR.addr)
         intFile.fromCSR.wdata           := sel(fromCSR.wdata)
         intFile.fromCSR.claim           := fromCSR.claims(pi) & intFilesSelOH(flati)

--- a/test/imsic/main.py
+++ b/test/imsic/main.py
@@ -34,7 +34,7 @@ async def imsic_1_test(dut):
   # Initialize ready signals
   dut.toaia_0_d_ready.value = 1
 
-  await RisingEdge(dut.clock)
+  await FallingEdge(dut.clock)
 
   # Initialize IMSIC
   await init_imsic(dut)
@@ -47,6 +47,7 @@ async def imsic_1_test(dut):
   cocotb.log.info("mseteipnum began")
   await m_int(dut, 1996%256)
   topeis_0 = wrap_topei(1996%256)
+  await FallingEdge(dut.clock) ## delay one cycle caused by RegGen.
   assert dut.toCSR1_topeis_0.value == topeis_0
   dut.toCSR1_pendings_0.value = 1
   cocotb.log.info("mseteipnum passed")
@@ -60,8 +61,10 @@ async def imsic_1_test(dut):
   # 2_mseteipnum_1_bits_mclaim began
   cocotb.log.info("2_mseteipnum_1_bits_mclaim began")
   await m_int(dut, 12)
+  await FallingEdge(dut.clock) ## delay one cycle caused by RegGen.
   assert dut.toCSR1_topeis_0.value == wrap_topei(12)
   await m_int(dut, 8)
+  await FallingEdge(dut.clock) ## delay one cycle caused by RegGen.
   assert dut.toCSR1_topeis_0.value == wrap_topei(8)
   await claim(dut)
   assert dut.toCSR1_topeis_0.value == wrap_topei(12)
@@ -117,7 +120,7 @@ async def imsic_1_test(dut):
   # read_csr:eie began
   cocotb.log.info("read_csr:eie began")
   await read_csr(dut, csr_addr_eie0)
-  await RisingEdge(dut.clock)
+  await FallingEdge(dut.clock)
   # toCSR1_rdata_bits = dut.toCSR1_rdata_bits.value
   # eies_0 = dut.imsic_1.imsic.intFile.eies_0.value
   # assert toCSR1_rdata_bits == eies_0
@@ -128,6 +131,7 @@ async def imsic_1_test(dut):
   await select_s_intfile(dut)
   assert dut.toCSR1_topeis_1.value == wrap_topei(0)
   await s_int(dut, 1234%256)
+  await FallingEdge(dut.clock) ## delay one cycle caused by RegGen.
   assert dut.toCSR1_topeis_1.value == wrap_topei(1234%256)
   dut.toCSR1_pendings_1.value = 1
   await select_m_intfile(dut)
@@ -138,6 +142,7 @@ async def imsic_1_test(dut):
   await select_vs_intfile(dut, 2)
   assert dut.toCSR1_topeis_2.value == wrap_topei(0)
   await v_int_vgein(dut, 137)
+  await FallingEdge(dut.clock)
   assert dut.toCSR1_topeis_2.value == wrap_topei(137)
   dut.toCSR1_pendings_4.value = 1  # Assuming pendings_4 corresponds to vgein=2
   await select_m_intfile(dut)
@@ -188,7 +193,7 @@ async def imsic_1_test(dut):
   await write_csr(dut, csr_addr_eip0, 0x1)
   await read_csr(dut, csr_addr_eip0)
   for _ in range(10):
-    await RisingEdge(dut.clock)
+    await FallingEdge(dut.clock)
     if dut.toCSR1_rdata_valid.value == 1:
       break
   else:
@@ -200,7 +205,7 @@ async def imsic_1_test(dut):
   await m_int(dut, 0)
   await read_csr(dut, csr_addr_eip0)
   for _ in range(10):
-    await RisingEdge(dut.clock)
+    await FallingEdge(dut.clock)
     if dut.toCSR1_rdata_valid.value == 1:
       break
   else:


### PR DESCRIPTION
modify：IMSIC.scala,refactor the IMSIC code. Divided into two parts: one part is bus logic, one part is csr logic, for more flexible integration of IMSIC.