### PR TITLE
fix issue when fifo is not full constantly

### DIFF
--- a/src/main/scala/IMSIC.scala
+++ b/src/main/scala/IMSIC.scala
@@ -682,9 +682,9 @@ class TLRegIMSIC(
     val msi_vld_ack_soc_ris = msi_vld_ack_soc & (~msi_vld_ack_soc_1f)
     //    val fifo_empty = ~fifo_sync.io.deq.valid
     // msi_vld_req : high when fifo empty is false, low when ack is high. and io.deq.valid := ~empty
-    when(fifo_sync.io.deq.valid === true.B) {
+    when(msi_vld_ack_soc_ris) {
       msi_vld_req := true.B
-    }.elsewhen(msi_vld_ack_soc_ris) {
+    }.elsewhen(fifo_sync.io.deq.valid === true.B) {
       msi_vld_req := false.B
     }.otherwise {
       msi_vld_req := msi_vld_req

--- a/src/main/scala/IMSIC.scala
+++ b/src/main/scala/IMSIC.scala
@@ -683,9 +683,9 @@ class TLRegIMSIC(
     //    val fifo_empty = ~fifo_sync.io.deq.valid
     // msi_vld_req : high when fifo empty is false, low when ack is high. and io.deq.valid := ~empty
     when(msi_vld_ack_soc_ris) {
-      msi_vld_req := true.B
-    }.elsewhen(fifo_sync.io.deq.valid === true.B) {
       msi_vld_req := false.B
+    }.elsewhen(fifo_sync.io.deq.valid === true.B) {
+      msi_vld_req := true.B
     }.otherwise {
       msi_vld_req := msi_vld_req
     }
@@ -762,10 +762,10 @@ class AXIRegIMSIC(
     val msi_vld_ack_soc_ris = msi_vld_ack_soc & (~msi_vld_ack_soc_1f)
     // val fifo_empty = ~fifo_sync.io.deq.valid
     // msi_vld_req : high when fifo empty is false, low when ack is high. and io.deq.valid := ~empty
-    when(fifo_sync.io.deq.valid === true.B) {
-      msi_vld_req := true.B
-    }.elsewhen(msi_vld_ack_soc_ris) {
+    when(msi_vld_ack_soc_ris) {
       msi_vld_req := false.B
+    }.elsewhen(fifo_sync.io.deq.valid === true.B) {
+      msi_vld_req := true.B
     }.otherwise {
       msi_vld_req := msi_vld_req
     }


### PR DESCRIPTION
1.msi_vld_req need to be cleared once msi_vld_ack is high 
2.the priority is higher than fifo is not empty. 
3.only this ,fifo deq.ready can be active. 
4.at last ,fifo rdata valid can be active.