### PR TITLE
fix(IMSIC): declare AXI slave interleaved ID

### DIFF
--- a/src/main/scala/IMSIC.scala
+++ b/src/main/scala/IMSIC.scala
@@ -680,7 +680,8 @@ class AXIRegIMSIC_WRAP(
         AddressSet(params.mAddr, pow2(params.intFileMemWidth) - 1),
         AddressSet(params.sgAddr, pow2(params.intFileMemWidth) * pow2(log2Ceil(1 + params.geilen)) - 1)),
         supportsWrite = TransferSizes(1, beatBytes),
-        supportsRead = TransferSizes(1, beatBytes)
+        supportsRead = TransferSizes(1, beatBytes),
+        interleavedId = Some(0)
       )),
       beatBytes = beatBytes
     )))
@@ -692,7 +693,8 @@ class AXIRegIMSIC_WRAP(
           AddressSet(params.tee_mAddr, pow2(params.intFileMemWidth) - 1),
           AddressSet(params.tee_sgAddr, pow2(params.intFileMemWidth) * pow2(log2Ceil(1 + params.geilen)) - 1)),
         supportsWrite = TransferSizes(1, beatBytes),
-        supportsRead = TransferSizes(1, beatBytes)
+        supportsRead = TransferSizes(1, beatBytes),
+        interleavedId = Some(0)
       )),
       beatBytes = beatBytes
     )))


### PR DESCRIPTION
AXIRegIMSIC_WRAP is consumed by RocketChip AXI4 diplomacy. TLToAXI4 requires every reachable AXI4 slave to define the same interleavedId, so mark the REE and TEE IMSIC slave ports as non-interleaving.

This only describes the AXI response ordering guarantee and does not change the IMSIC register FSM or AXI write handshake behavior.